### PR TITLE
updates to TownNames object, and viewmodel cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,13 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+tab_width = 4
+indent_size = 4
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
 
 # C# files
 [*.csproj]
@@ -325,7 +332,7 @@ dotnet_diagnostic.CA1825.severity = none
 dotnet_diagnostic.CA2201.severity = warning
 dotnet_diagnostic.CA2208.severity = none
 dotnet_diagnostic.CA2225.severity = none
-dotnet_diagnostic.CA2227.severity = suggestion
+dotnet_diagnostic.CA2227.severity = none
 
 dotnet_diagnostic.CS8032.severity = none
 dotnet_diagnostic.CS8602.severity = warning # do not change: DAT treats this as error so we need to match it

--- a/Dat/Objects/TownNamesObject.cs
+++ b/Dat/Objects/TownNamesObject.cs
@@ -8,9 +8,9 @@ namespace OpenLoco.Dat.Objects
 {
 	[TypeConverter(typeof(ExpandableObjectConverter))]
 	[LocoStructSize(0x04)]
-	public record TownNamesUnk(
+	public record Category(
 		[property: LocoStructOffset(0x00)] uint8_t Count,
-		[property: LocoStructOffset(0x01)] uint8_t Fill,
+		[property: LocoStructOffset(0x01)] uint8_t Bias,
 		[property: LocoStructOffset(0x02)] uint16_t Offset
 		) : ILocoStruct
 	{
@@ -23,9 +23,11 @@ namespace OpenLoco.Dat.Objects
 	[LocoStringTable("Name")]
 	public record TownNamesObject(
 		[property: LocoStructOffset(0x00), LocoString, Browsable(false)] string_id Name,
-		[property: LocoStructOffset(0x02), LocoArrayLength(6)] TownNamesUnk[] UnknownTownNameStructs
+		[property: LocoStructOffset(0x02), LocoArrayLength(6)] Category[] Categories
 	) : ILocoStruct, ILocoStructVariableData
 	{
+		public const int MinNumNameCombinations = 80;
+
 		byte[] tempUnkVariableData;
 
 		public ReadOnlySpan<byte> Load(ReadOnlySpan<byte> remainingData)

--- a/Gui/ViewModels/DatTypes/GenericObjectViewModel.cs
+++ b/Gui/ViewModels/DatTypes/GenericObjectViewModel.cs
@@ -1,0 +1,16 @@
+using OpenLoco.Dat.Types;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using System.ComponentModel;
+
+namespace OpenLoco.Gui.ViewModels
+{
+	[TypeConverter(typeof(ExpandableObjectConverter))]
+	public class GenericObjectViewModel : ReactiveObject, IObjectViewModel
+	{
+		[Reactive] public required ILocoStruct Object { get; set; }
+
+		public ILocoStruct GetAsLocoStruct(ILocoStruct locoStruct)
+			=> locoStruct;
+	}
+}

--- a/Gui/ViewModels/DatTypes/IObjectViewModel.cs
+++ b/Gui/ViewModels/DatTypes/IObjectViewModel.cs
@@ -1,0 +1,9 @@
+using OpenLoco.Dat.Types;
+
+namespace OpenLoco.Gui.ViewModels
+{
+	public interface IObjectViewModel
+	{
+		ILocoStruct GetAsLocoStruct(ILocoStruct locoStruct);
+	}
+}

--- a/Gui/ViewModels/DatTypes/TownNamesViewModel.cs
+++ b/Gui/ViewModels/DatTypes/TownNamesViewModel.cs
@@ -11,12 +11,12 @@ namespace OpenLoco.Gui.ViewModels
 	{
 		[Reactive, Length(6, 6), Editable(false)] public BindingList<Category> Categories { get; set; }
 
-		public TownNamesViewModel(TownNamesObject veh) => Categories = new(veh.Categories);
+		public TownNamesViewModel(TownNamesObject tno) => Categories = new(tno.Categories);
 
 		public ILocoStruct GetAsLocoStruct(ILocoStruct locoStruct)
-			=> GetAsVehicleStruct((locoStruct as TownNamesObject)!);
+			=> GetAsStruct((locoStruct as TownNamesObject)!);
 
-		public TownNamesObject GetAsVehicleStruct(TownNamesObject baseTownNames)
+		public TownNamesObject GetAsStruct(TownNamesObject baseTownNames)
 			=> baseTownNames;
 	}
 }

--- a/Gui/ViewModels/DatTypes/TownNamesViewModel.cs
+++ b/Gui/ViewModels/DatTypes/TownNamesViewModel.cs
@@ -1,0 +1,22 @@
+using OpenLoco.Dat.Objects;
+using OpenLoco.Dat.Types;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace OpenLoco.Gui.ViewModels
+{
+	public class TownNamesViewModel : ReactiveObject, IObjectViewModel
+	{
+		[Reactive, Length(6, 6), Editable(false)] public BindingList<Category> Categories { get; set; }
+
+		public TownNamesViewModel(TownNamesObject veh) => Categories = new(veh.Categories);
+
+		public ILocoStruct GetAsLocoStruct(ILocoStruct locoStruct)
+			=> GetAsVehicleStruct((locoStruct as TownNamesObject)!);
+
+		public TownNamesObject GetAsVehicleStruct(TownNamesObject baseTownNames)
+			=> baseTownNames;
+	}
+}

--- a/Gui/ViewModels/DatTypes/VehicleViewModel.cs
+++ b/Gui/ViewModels/DatTypes/VehicleViewModel.cs
@@ -4,16 +4,10 @@ using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 
 namespace OpenLoco.Gui.ViewModels
 {
-	public interface IObjectViewModel;
-
-	[TypeConverter(typeof(ExpandableObjectConverter))]
-	public class GenericObjectViewModel : ReactiveObject, IObjectViewModel
-	{
-		[Reactive] public required ILocoStruct Object { get; set; }
-	}
 
 	public class VehicleViewModel : ReactiveObject, IObjectViewModel
 	{
@@ -55,6 +49,88 @@ namespace OpenLoco.Gui.ViewModels
 		[Reactive, Category("Sound")] public Engine1Sound? Engine1Sound { get; set; }
 		[Reactive, Category("Sound")] public Engine2Sound? Engine2Sound { get; set; }
 		[Reactive, Category("Sound")] public BindingList<S5Header> StartSounds { get; set; }
+
+		public VehicleViewModel(VehicleObject veh)
+		{
+			Mode = veh.Mode;
+			Type = veh.Type;
+			var_04 = veh.var_04;
+			TrackTypeId = veh.TrackTypeId;
+			CostIndex = veh.CostIndex;
+			CostFactor = veh.CostFactor;
+			Reliability = veh.Reliability;
+			RunCostIndex = veh.RunCostIndex;
+			RunCostFactor = veh.RunCostFactor;
+			ColourType = veh.ColourType;
+			CompatibleVehicles = new(veh.CompatibleVehicles);
+			RequiredTrackExtras = new(veh.RequiredTrackExtras);
+			CarComponents = new(veh.CarComponents);
+			BodySprites = new(veh.BodySprites);
+			BogieSprites = new(veh.BogieSprites);
+			Power = veh.Power;
+			Speed = veh.Speed;
+			RackSpeed = veh.RackSpeed;
+			Weight = veh.Weight;
+			Flags = veh.Flags;
+			MaxCargo = new(veh.MaxCargo);
+			CompatibleCargoCategories1 = new(veh.CompatibleCargoCategories[0]);
+			CompatibleCargoCategories2 = new(veh.CompatibleCargoCategories[1]);
+			CargoTypeSpriteOffsets = new(veh.CargoTypeSpriteOffsets.Select(x => new CargoTypeSpriteOffset(x.Key, x.Value)).ToList());
+			Animation = new(veh.Animation);
+			AnimationHeaders = new(veh.AnimationHeaders);
+			var_113 = veh.var_113;
+			DesignedYear = veh.ObsoleteYear;
+			ObsoleteYear = veh.ObsoleteYear;
+			RackRailType = veh.RackRailType;
+			SoundType = veh.SoundType;
+			StartSounds = new(veh.StartSounds);
+			FrictionSound = veh.SoundPropertyFriction;
+			Engine1Sound = veh.SoundPropertyEngine1;
+			Engine2Sound = veh.SoundPropertyEngine2;
+		}
+
+		public ILocoStruct GetAsLocoStruct(ILocoStruct locoStruct) => GetAsVehicleStruct((locoStruct as VehicleObject)!);
+
+		public VehicleObject GetAsVehicleStruct(VehicleObject baseVehicle)
+		{
+			// convert VehicleVM back to DAT, eg cargo sprites, string table, etc
+			// this can probably go in VehicleViewModelClass
+			foreach (var ctso in CargoTypeSpriteOffsets)
+			{
+				baseVehicle.CargoTypeSpriteOffsets[ctso.CargoCategory] = ctso.Offset;
+			}
+
+			return baseVehicle with
+			{
+				Mode = Mode,
+				Type = Type,
+				var_04 = var_04,
+				TrackTypeId = TrackTypeId,
+				CostIndex = CostIndex,
+				CostFactor = CostFactor,
+				Reliability = Reliability,
+				RunCostIndex = RunCostIndex,
+				RunCostFactor = RunCostFactor,
+				ColourType = ColourType,
+				Power = Power,
+				Speed = Speed,
+				RackSpeed = RackSpeed,
+				Weight = Weight,
+				Flags = Flags,
+				var_113 = var_113,
+				DesignedYear = DesignedYear,
+				ObsoleteYear = ObsoleteYear,
+				RackRailType = RackRailType,
+				SoundType = SoundType,
+				SoundPropertyFriction = FrictionSound,
+				SoundPropertyEngine1 = Engine1Sound,
+				SoundPropertyEngine2 = Engine2Sound,
+				NumCompatibleVehicles = (byte)CompatibleVehicles.Count,
+				NumRequiredTrackExtras = (byte)RequiredTrackExtras.Count,
+				NumStartSounds = (byte)StartSounds.Count,
+			};
+		}
+
 	}
 
 	[TypeConverter(typeof(ExpandableObjectConverter))]

--- a/Gui/ViewModels/DatTypes/VehicleViewModel.cs
+++ b/Gui/ViewModels/DatTypes/VehicleViewModel.cs
@@ -8,7 +8,6 @@ using System.Linq;
 
 namespace OpenLoco.Gui.ViewModels
 {
-
 	public class VehicleViewModel : ReactiveObject, IObjectViewModel
 	{
 		[Reactive, Category("Stats")] public TransportMode Mode { get; set; }
@@ -89,18 +88,16 @@ namespace OpenLoco.Gui.ViewModels
 			Engine2Sound = veh.SoundPropertyEngine2;
 		}
 
-		public ILocoStruct GetAsLocoStruct(ILocoStruct locoStruct) => GetAsVehicleStruct((locoStruct as VehicleObject)!);
+		public ILocoStruct GetAsLocoStruct(ILocoStruct locoStruct) => GetAsStruct((locoStruct as VehicleObject)!);
 
-		public VehicleObject GetAsVehicleStruct(VehicleObject baseVehicle)
+		public VehicleObject GetAsStruct(VehicleObject veh)
 		{
-			// convert VehicleVM back to DAT, eg cargo sprites, string table, etc
-			// this can probably go in VehicleViewModelClass
 			foreach (var ctso in CargoTypeSpriteOffsets)
 			{
-				baseVehicle.CargoTypeSpriteOffsets[ctso.CargoCategory] = ctso.Offset;
+				veh.CargoTypeSpriteOffsets[ctso.CargoCategory] = ctso.Offset;
 			}
 
-			return baseVehicle with
+			return veh with
 			{
 				Mode = Mode,
 				Type = Type,
@@ -130,7 +127,6 @@ namespace OpenLoco.Gui.ViewModels
 				NumStartSounds = (byte)StartSounds.Count,
 			};
 		}
-
 	}
 
 	[TypeConverter(typeof(ExpandableObjectConverter))]

--- a/Gui/Views/MainWindow.axaml
+++ b/Gui/Views/MainWindow.axaml
@@ -181,6 +181,10 @@
 			<pgc:PropertyGrid x:Name="propertyGrid_VehicleVm" DataContext="{Binding}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
 		</DataTemplate>
 
+		<DataTemplate DataType="vm:TownNamesViewModel">
+			<pgc:PropertyGrid x:Name="propertyGrid_TownNamesVm" DataContext="{Binding}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False" ShowStyle="Builtin" Background="{DynamicResource ExpanderContentBackground}"></pgc:PropertyGrid>
+		</DataTemplate>
+
 		<DataTemplate DataType="vm:DatObjectEditorViewModel">
 			<DockPanel DataContext="{Binding}" Margin="10">
 				<Grid ColumnDefinitions="*, Auto, 384">

--- a/Gui/Views/MainWindow.axaml
+++ b/Gui/Views/MainWindow.axaml
@@ -328,15 +328,15 @@
 					<GridSplitter Grid.Column="1" />
 					<TabControl Grid.Column="2">
 						<TabItem Header="Headers">
-							<Border Background="{DynamicResource ExpanderContentBackground}" Margin="8">
-								<StackPanel Margin="8">
+							<Border Margin="4" Background="{DynamicResource ExpanderContentBackground}">
+								<StackPanel Margin="4">
 									<ContentControl Content="{Binding CurrentObject.DatFileInfo.S5Header}"></ContentControl>
 									<ContentControl Content="{Binding CurrentObject.DatFileInfo.ObjectHeader}"></ContentControl>
 								</StackPanel>
 							</Border>
 						</TabItem>
-						<TabItem Header="Hex Dump">
-							<DockPanel>
+						<TabItem Header="Hex Dump" >
+							<DockPanel Margin="4" Background="{DynamicResource ExpanderContentBackground}">
 								<ScrollViewer>
 									<TreeView ItemsSource="{Binding CurrentHexAnnotations}" SelectedItem="{Binding CurrentlySelectedHexAnnotation}" Margin="4" DockPanel.Dock="Left" >
 										<TreeView.ItemTemplate>
@@ -382,18 +382,27 @@
 		<DataTemplate DataType="vm:SCV5ViewModel">
 			<TabControl>
 				<TabItem Header="Header">
-					<pgc:PropertyGrid x:Name="propertyGrid_ScenarioSaveGameVmHeader" DataContext="{Binding CurrentS5File.Header}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
+					<ScrollViewer>
+						<pgc:PropertyGrid x:Name="propertyGrid_ScenarioSaveGameVmHeader" DataContext="{Binding CurrentS5File.Header}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
+					</ScrollViewer>
 				</TabItem>
 				<TabItem Header="Landscape">
-					<pgc:PropertyGrid x:Name="propertyGrid_ScenarioSaveGameVmLandscape" DataContext="{Binding CurrentS5File.LandscapeOptions}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
+					<ScrollViewer>
+						<pgc:PropertyGrid x:Name="propertyGrid_ScenarioSaveGameVmLandscape" DataContext="{Binding CurrentS5File.LandscapeOptions}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
+					</ScrollViewer>
 				</TabItem>
 				<TabItem Header="SaveGame">
-					<pgc:PropertyGrid x:Name="propertyGrid_ScenarioSaveGameVmSave" DataContext="{Binding CurrentS5File.SaveDetails}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
+					<ScrollViewer>
+						<pgc:PropertyGrid x:Name="propertyGrid_ScenarioSaveGameVmSave" DataContext="{Binding CurrentS5File.SaveDetails}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
+					</ScrollViewer>
 				</TabItem>
 				<TabItem Header="GameState">
-					<pgc:PropertyGrid x:Name="propertyGrid_ScenarioSaveGameVmGameState" DataContext="{Binding CurrentS5File.GameState}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
+					<ScrollViewer>
+						<pgc:PropertyGrid x:Name="propertyGrid_ScenarioSaveGameVmGameState" DataContext="{Binding CurrentS5File.GameState}" Margin="2" ShowTitle="False" AllowFilter="False" AllowQuickFilter="False"></pgc:PropertyGrid>
+					</ScrollViewer>
 				</TabItem>
 				<TabItem Header="Required Objects">
+
 					<DockPanel>
 						<TextBlock Text="{Binding RequiredObjects.Count}" DockPanel.Dock="Top" />
 						<ScrollViewer>

--- a/Tests/LoadSaveTests.cs
+++ b/Tests/LoadSaveTests.cs
@@ -762,29 +762,29 @@ namespace OpenLoco.Dat.Tests
 		{
 			void assertFunc(ILocoObject obj, TownNamesObject struc) => Assert.Multiple(() =>
 			{
-				Assert.That(struc.UnknownTownNameStructs[0].Count, Is.EqualTo(2), nameof(struc.UnknownTownNameStructs) + "[0] Count");
-				Assert.That(struc.UnknownTownNameStructs[0].Fill, Is.EqualTo(30), nameof(struc.UnknownTownNameStructs) + "[0] Fill");
-				Assert.That(struc.UnknownTownNameStructs[0].Offset, Is.EqualTo(93), nameof(struc.UnknownTownNameStructs) + "[0] Offset");
+				Assert.That(struc.Categories[0].Count, Is.EqualTo(2), nameof(struc.Categories) + "[0] Count");
+				Assert.That(struc.Categories[0].Bias, Is.EqualTo(30), nameof(struc.Categories) + "[0] Bias");
+				Assert.That(struc.Categories[0].Offset, Is.EqualTo(93), nameof(struc.Categories) + "[0] Offset");
 
-				Assert.That(struc.UnknownTownNameStructs[1].Count, Is.EqualTo(94), nameof(struc.UnknownTownNameStructs) + "[1] Count");
-				Assert.That(struc.UnknownTownNameStructs[1].Fill, Is.EqualTo(0), nameof(struc.UnknownTownNameStructs) + "[1] Fill");
-				Assert.That(struc.UnknownTownNameStructs[1].Offset, Is.EqualTo(110), nameof(struc.UnknownTownNameStructs) + "[1] Offset");
+				Assert.That(struc.Categories[1].Count, Is.EqualTo(94), nameof(struc.Categories) + "[1] Count");
+				Assert.That(struc.Categories[1].Bias, Is.EqualTo(0), nameof(struc.Categories) + "[1] Bias");
+				Assert.That(struc.Categories[1].Offset, Is.EqualTo(110), nameof(struc.Categories) + "[1] Offset");
 
-				Assert.That(struc.UnknownTownNameStructs[2].Count, Is.EqualTo(0), nameof(struc.UnknownTownNameStructs) + "[2] Count");
-				Assert.That(struc.UnknownTownNameStructs[2].Fill, Is.EqualTo(0), nameof(struc.UnknownTownNameStructs) + "[2] Fill");
-				Assert.That(struc.UnknownTownNameStructs[2].Offset, Is.EqualTo(0), nameof(struc.UnknownTownNameStructs) + "[2] Offset");
+				Assert.That(struc.Categories[2].Count, Is.EqualTo(0), nameof(struc.Categories) + "[2] Count");
+				Assert.That(struc.Categories[2].Bias, Is.EqualTo(0), nameof(struc.Categories) + "[2] Bias");
+				Assert.That(struc.Categories[2].Offset, Is.EqualTo(0), nameof(struc.Categories) + "[2] Offset");
 
-				Assert.That(struc.UnknownTownNameStructs[3].Count, Is.EqualTo(0), nameof(struc.UnknownTownNameStructs) + "[3] Count");
-				Assert.That(struc.UnknownTownNameStructs[3].Fill, Is.EqualTo(0), nameof(struc.UnknownTownNameStructs) + "[3] Fill");
-				Assert.That(struc.UnknownTownNameStructs[3].Offset, Is.EqualTo(0), nameof(struc.UnknownTownNameStructs) + "[3] Offset");
+				Assert.That(struc.Categories[3].Count, Is.EqualTo(0), nameof(struc.Categories) + "[3] Count");
+				Assert.That(struc.Categories[3].Bias, Is.EqualTo(0), nameof(struc.Categories) + "[3] Bias");
+				Assert.That(struc.Categories[3].Offset, Is.EqualTo(0), nameof(struc.Categories) + "[3] Offset");
 
-				Assert.That(struc.UnknownTownNameStructs[4].Count, Is.EqualTo(18), nameof(struc.UnknownTownNameStructs) + "[4] Count");
-				Assert.That(struc.UnknownTownNameStructs[4].Fill, Is.EqualTo(0), nameof(struc.UnknownTownNameStructs) + "[4] Fill");
-				Assert.That(struc.UnknownTownNameStructs[4].Offset, Is.EqualTo(923), nameof(struc.UnknownTownNameStructs) + "[4] Offset");
+				Assert.That(struc.Categories[4].Count, Is.EqualTo(18), nameof(struc.Categories) + "[4] Count");
+				Assert.That(struc.Categories[4].Bias, Is.EqualTo(0), nameof(struc.Categories) + "[4] Bias");
+				Assert.That(struc.Categories[4].Offset, Is.EqualTo(923), nameof(struc.Categories) + "[4] Offset");
 
-				Assert.That(struc.UnknownTownNameStructs[5].Count, Is.EqualTo(6), nameof(struc.UnknownTownNameStructs) + "[5] Count");
-				Assert.That(struc.UnknownTownNameStructs[5].Fill, Is.EqualTo(20), nameof(struc.UnknownTownNameStructs) + "[5] Fill");
-				Assert.That(struc.UnknownTownNameStructs[5].Offset, Is.EqualTo(1071), nameof(struc.UnknownTownNameStructs) + "[5] Offset");
+				Assert.That(struc.Categories[5].Count, Is.EqualTo(6), nameof(struc.Categories) + "[5] Count");
+				Assert.That(struc.Categories[5].Bias, Is.EqualTo(20), nameof(struc.Categories) + "[5] Bias");
+				Assert.That(struc.Categories[5].Offset, Is.EqualTo(1071), nameof(struc.Categories) + "[5] Offset");
 
 				Assert.That(obj.StringTable["Name"][LanguageId.English_UK], Is.EqualTo("North-American style town names"));
 				Assert.That(obj.StringTable["Name"][LanguageId.English_US], Is.EqualTo("North-American style town names"));


### PR DESCRIPTION
TownNames recently had some small variable name updates in OpenLoco so I've ported them across. As part of the ongoing effort to 'fix' all the object views by giving them individual viewmodels, I've also made one for TownNames here and refactored the existing code to better support this pattern