### PR TITLE
Use absolute path when displaying objects

### DIFF
--- a/Dat/ObjectIndex.cs
+++ b/Dat/ObjectIndex.cs
@@ -166,6 +166,7 @@ namespace OpenLoco.Dat
 		ObjectSource ObjectSource,
 		VehicleType? VehicleType = null)
 	{
-		public string SimpleText => $"{DatName} | {Filename}";
+		public string SimpleText
+			=> $"{DatName} | {Filename}";
 	}
 }

--- a/Gui/Models/FileSystemItems.cs
+++ b/Gui/Models/FileSystemItems.cs
@@ -12,24 +12,8 @@ namespace OpenLoco.Gui.Models
 		Online,
 	}
 
-	public abstract record FileSystemItemBase
+	public abstract record FileSystemItemBase(string Filename, string DisplayName, ObservableCollection<FileSystemItemBase>? SubNodes = null)
 	{
-		protected FileSystemItemBase(string filename, string displayName, ObservableCollection<FileSystemItemBase>? subNodes)
-		{
-			//if (!File.Exists(filename))
-			//{
-			//throw new FileNotFoundException();
-			//}
-
-			Filename = filename ?? throw new ArgumentNullException(nameof(filename));
-			DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
-			SubNodes = subNodes;
-		}
-
-		public string Filename { get; set; }
-		public string DisplayName { get; set; }
-		public ObservableCollection<FileSystemItemBase>? SubNodes { get; set; }
-
 		public string NameComputed
 			=> $"{DisplayName}{(SubNodes == null ? string.Empty : $" ({SubNodes.Count})")}"; // nested interpolated string...what have i become
 	}

--- a/Gui/Models/FileSystemItems.cs
+++ b/Gui/Models/FileSystemItems.cs
@@ -12,8 +12,24 @@ namespace OpenLoco.Gui.Models
 		Online,
 	}
 
-	public abstract record FileSystemItemBase(string Filename, string DisplayName, ObservableCollection<FileSystemItemBase>? SubNodes = null)
+	public abstract record FileSystemItemBase
 	{
+		protected FileSystemItemBase(string filename, string displayName, ObservableCollection<FileSystemItemBase>? subNodes)
+		{
+			//if (!File.Exists(filename))
+			//{
+			//throw new FileNotFoundException();
+			//}
+
+			Filename = filename ?? throw new ArgumentNullException(nameof(filename));
+			DisplayName = displayName ?? throw new ArgumentNullException(nameof(displayName));
+			SubNodes = subNodes;
+		}
+
+		public string Filename { get; set; }
+		public string DisplayName { get; set; }
+		public ObservableCollection<FileSystemItemBase>? SubNodes { get; set; }
+
 		public string NameComputed
 			=> $"{DisplayName}{(SubNodes == null ? string.Empty : $" ({SubNodes.Count})")}"; // nested interpolated string...what have i become
 	}
@@ -23,9 +39,6 @@ namespace OpenLoco.Gui.Models
 
 	public record FileSystemItemObject(string Filename, string DisplayName, FileLocation FileLocation, ObjectSource ObjectSource)
 		: FileSystemItem(Filename, DisplayName, FileLocation);
-
-	//public record FileSystemDatGroup(string Path, DatFileType DatFileType, ObservableCollection<FileSystemItemBase> SubNodes)
-	//	: FileSystemItemBase(Path, DatFileType.ToString(), SubNodes);
 
 	public record FileSystemItemGroup(string Filename, ObjectType ObjectType, ObservableCollection<FileSystemItemBase> SubNodes)
 		: FileSystemItemBase(Filename, ObjectType.ToString(), SubNodes);

--- a/Gui/ViewModels/DatTypes/DatObjectEditorViewModel.cs
+++ b/Gui/ViewModels/DatTypes/DatObjectEditorViewModel.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using OpenLoco.Dat;
 using OpenLoco.Dat.Data;
 using OpenLoco.Dat.FileParsing;
 using OpenLoco.Dat.Objects.Sound;
@@ -46,7 +45,7 @@ namespace OpenLoco.Gui.ViewModels
 		public ReactiveCommand<Unit, Unit> ViewHexCommand { get; }
 		public Interaction<HexWindowViewModel, HexWindowViewModel?> HexViewerShowDialog { get; }
 
-		public ReactiveCommand<Unit, ObjectIndexEntry?> SelectObjectCommand { get; }
+		//public ReactiveCommand<Unit, ObjectIndexEntry?> SelectObjectCommand { get; }
 		public Interaction<ObjectSelectionWindowViewModel, ObjectSelectionWindowViewModel?> SelectObjectShowDialog { get; }
 
 		public DatObjectEditorViewModel(FileSystemItemObject currentFile, ObjectEditorModel model)
@@ -61,20 +60,20 @@ namespace OpenLoco.Gui.ViewModels
 
 			ViewHexCommand = ReactiveCommand.CreateFromTask(async () =>
 			{
-				var filename = Path.Combine(Model.Settings.ObjDataDirectory, CurrentFile.Filename);
-				var vm = new HexWindowViewModel(filename, logger);
+				var vm = new HexWindowViewModel(CurrentFile.Filename, logger);
 				_ = await HexViewerShowDialog.Handle(vm);
 			});
 
 			SelectObjectShowDialog = new();
 			_ = SelectObjectShowDialog.RegisterHandler(DoShowDialogAsync<ObjectSelectionWindowViewModel, ObjectSelectionWindow>);
-			SelectObjectCommand = ReactiveCommand.CreateFromTask(async () =>
-			{
-				var objects = model.ObjectIndex.Objects.Where(x => x.ObjectType == ObjectType.Tree);
-				var vm = new ObjectSelectionWindowViewModel(objects);
-				var result = await SelectObjectShowDialog.Handle(vm);
-				return result.SelectedObject;
-			});
+
+			//SelectObjectCommand = ReactiveCommand.CreateFromTask(async () =>
+			//{
+			//	var objects = model.ObjectIndex.Objects.Where(x => x.ObjectType == ObjectType.Tree);
+			//	var vm = new ObjectSelectionWindowViewModel(objects);
+			//	var result = await SelectObjectShowDialog.Handle(vm);
+			//	return result.SelectedObject;
+			//});
 		}
 
 		static async Task DoShowDialogAsync<TViewModel, TWindow>(IInteractionContext<TViewModel, TViewModel?> interaction) where TWindow : Window, new()
@@ -168,25 +167,25 @@ namespace OpenLoco.Gui.ViewModels
 			}
 
 			// delete file
-			var path = Path.Combine(Model.Settings.ObjDataDirectory, CurrentFile.Filename);
-			if (File.Exists(path))
+			if (File.Exists(CurrentFile.Filename))
 			{
-				logger.Info($"Deleting file \"{path}\"");
-				File.Delete(path);
+				logger.Info($"Deleting file \"{CurrentFile.Filename}\"");
+				File.Delete(CurrentFile.Filename);
 			}
 			else
 			{
-				logger.Info($"File already deleted \"{path}\"");
+				logger.Info($"File already deleted \"{CurrentFile.Filename}\"");
 			}
 
 			// remove from object index
-			Model.ObjectIndex.Delete(x => x.Filename == CurrentFile.Filename);
+			// todo: reimplement with absolute path for CurrentFile.Filename
+			//Model.ObjectIndex.Delete(x => x.Filename == CurrentFile.Filename);
 		}
 
 		public override void Save()
 		{
 			var savePath = CurrentFile.FileLocation == FileLocation.Local
-				? Path.Combine(Model.Settings.ObjDataDirectory, CurrentFile.Filename)
+				? CurrentFile.Filename
 				: Path.Combine(Model.Settings.DownloadFolder, Path.ChangeExtension(CurrentFile.DisplayName, ".dat"));
 			SaveCore(savePath);
 		}

--- a/Gui/ViewModels/DatTypes/DatObjectEditorViewModel.cs
+++ b/Gui/ViewModels/DatTypes/DatObjectEditorViewModel.cs
@@ -177,9 +177,9 @@ namespace OpenLoco.Gui.ViewModels
 				logger.Info($"File already deleted \"{CurrentFile.Filename}\"");
 			}
 
-			// remove from object index
-			// todo: reimplement with absolute path for CurrentFile.Filename
-			//Model.ObjectIndex.Delete(x => x.Filename == CurrentFile.Filename);
+			// note: it is not really possible to delete the entry from the index since if the user
+			// has changed objdata folders but still has this item tab open, then there is no way
+			// to delete. user can reindex to fix, or rely on automatic reindex at startup
 		}
 
 		public override void Save()

--- a/Gui/ViewModels/FolderTreeViewModel.cs
+++ b/Gui/ViewModels/FolderTreeViewModel.cs
@@ -180,6 +180,7 @@ namespace OpenLoco.Gui.ViewModels
 			await Model.LoadObjDirectoryAsync(directory, Progress, useExistingIndex);
 			LocalDirectoryItems = ConstructTreeView(
 				Model.ObjectIndex.Objects.Where(x => (int)x.ObjectType < Limits.kMaxObjectTypes),
+				Model.Settings.ObjDataDirectory,
 				FilenameFilter,
 				DisplayMode,
 				FileLocation.Local);
@@ -204,13 +205,14 @@ namespace OpenLoco.Gui.ViewModels
 			{
 				OnlineDirectoryItems = ConstructTreeView(
 					Model.ObjectIndexOnline.Objects.Where(x => (int)x.ObjectType < Limits.kMaxObjectTypes),
+					Model.Settings.DownloadFolder,
 					FilenameFilter,
 					DisplayMode,
 					FileLocation.Online);
 			}
 		}
 
-		static List<FileSystemItemBase> ConstructTreeView(IEnumerable<ObjectIndexEntry> index, string filenameFilter, ObjectDisplayMode displayMode, FileLocation fileLocation)
+		static List<FileSystemItemBase> ConstructTreeView(IEnumerable<ObjectIndexEntry> index, string baseDirectory, string filenameFilter, ObjectDisplayMode displayMode, FileLocation fileLocation)
 		{
 			var result = new List<FileSystemItemBase>();
 
@@ -231,7 +233,7 @@ namespace OpenLoco.Gui.ViewModels
 						.OrderBy(vg => vg.Key.ToString()))
 					{
 						var vehicleSubNodes = new ObservableCollection<FileSystemItemBase>(vg
-							.Select(o => new FileSystemItemObject(o.Filename, o.DatName, fileLocation, o.ObjectSource))
+							.Select(o => new FileSystemItemObject(Path.Combine(baseDirectory, o.Filename), o.DatName, fileLocation, o.ObjectSource))
 							.OrderBy(o => o.DisplayName));
 
 						if (vg.Key == null)
@@ -250,7 +252,7 @@ namespace OpenLoco.Gui.ViewModels
 				else
 				{
 					subNodes = new ObservableCollection<FileSystemItemBase>(objGroup
-						.Select(o => new FileSystemItemObject(o.Filename, o.DatName, fileLocation, o.ObjectSource))
+						.Select(o => new FileSystemItemObject(Path.Combine(baseDirectory, o.Filename), o.DatName, fileLocation, o.ObjectSource))
 						.OrderBy(o => o.DisplayName));
 				}
 

--- a/Gui/Views/MainWindow.axaml
+++ b/Gui/Views/MainWindow.axaml
@@ -386,7 +386,7 @@
 					<TabItem Margin="0" Padding="0" BorderThickness="0" MaxHeight="32">
 						<TabItem.Header>
 							<StackPanel Orientation="Horizontal" Background="{DynamicResource ButtonBackground}">
-								<TextBlock Text="{Binding CurrentFile.DisplayName}" Margin="4" TextAlignment="Left" VerticalAlignment="Center"/>
+								<TextBlock Text="{Binding CurrentFile.DisplayName}" Margin="4" TextAlignment="Left" VerticalAlignment="Center" ToolTip.Tip="{Binding CurrentFile.Filename}" />
 								<Button BorderThickness="0" FontSize="12" VerticalAlignment="Center" Command="{Binding $parent[TabControl].((vm:TabViewPageViewModel)DataContext).RemoveTabCommand}" CommandParameter="{Binding}">X</Button>
 							</StackPanel>
 						</TabItem.Header>


### PR DESCRIPTION
Using the relative path "current objdata + filename" leads to issues when you load an object in a tab, change the current objdata folder, then try to do a file operation on the original file (save/reload/delete), which would try to concat the *new* objdata folder with the old filename. The solution is just to pass in the absolute path to the viewmodel for that object.